### PR TITLE
🪲 [Fix]: Fix linter settings and docs

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -8,18 +8,19 @@
 ###############
 # Rules by id #
 ###############
-MD004: false                  # Unordered list style
+MD004: false # Unordered list style
 MD007:
-  indent: 2                   # Unordered list indentation
+  indent: 2 # Unordered list indentation
 MD013:
-  line_length: 808            # Line length
+  line_length: 808 # Line length
+MD024: false # no-duplicate-heading, INPUTS and OUTPUTS _can_ be the same item
 MD026:
-  punctuation: ".,;:!。，；:"  # List of not allowed
-MD029: false                  # Ordered list item prefix
-MD033: false                  # Allow inline HTML
-MD036: false                  # Emphasis used instead of a heading
+  punctuation: '.,;:!。，；:' # List of not allowed
+MD029: false # Ordered list item prefix
+MD033: false # Allow inline HTML
+MD036: false # Emphasis used instead of a heading
 
 #################
 # Rules by tags #
 #################
-blank_lines: false  # Error on blank lines
+blank_lines: false # Error on blank lines


### PR DESCRIPTION
## Description

This pull request makes minor adjustments to the Markdown linter configuration. The main change is the disabling of the duplicate heading check to allow repeated headings like "INPUTS" and "OUTPUTS", and a small formatting update to the punctuation rule.

- Markdown linting configuration updates:
  * Disabled the `MD024` rule to permit duplicate headings, such as "INPUTS" and "OUTPUTS" (`.github/linters/.markdown-lint.yml`).
  * Changed the punctuation list for `MD026` to use single quotes for consistency (`.github/linters/.markdown-lint.yml`).